### PR TITLE
Issue3: Adding headline ancestors to the task headline

### DIFF
--- a/org-clock-csv-tests.el
+++ b/org-clock-csv-tests.el
@@ -32,6 +32,9 @@
   "Test tasks with commas in them, as in issue #2."
   (org-clock-csv-should-match "tests/issue-2.org" "tests/issue-2.csv"))
 
+(ert-deftest test-issue-3 ()
+  "Test tasks with headline ancestors, as in issue #3."
+  (org-clock-csv-should-match "tests/issue-3.org" "tests/issue-3.csv"))
 
 ;; Local Variables:
 ;; coding: utf-8

--- a/org-clock-csv.el
+++ b/org-clock-csv.el
@@ -79,7 +79,7 @@ See `org-clock-csv-default-row-fmt' for an example."
 (defun org-clock-csv-default-row-fmt (plist)
   "Default row formatting function."
   (mapconcat #'identity
-             (list (mapconcat (lambda (e) (org-clock-csv--escape e)) (plist-get plist ':task) org-clock-csv-headline-separator)
+             (list (org-clock-csv--escape (mapconcat #'identity (plist-get plist ':task) org-clock-csv-headline-separator))
                    (org-clock-csv--escape (plist-get plist ':category))
                    (plist-get plist ':start)
                    (plist-get plist ':end)

--- a/tests/issue-2.csv
+++ b/tests/issue-2.csv
@@ -1,2 +1,2 @@
-task,category,start,end,effort,ishabit,tags
-"Upgrade motherboard, CPU & RAM",,2012-11-29 13:05,2012-11-29 16:56,,,
+task,parents,category,start,end,effort,ishabit,tags
+"Upgrade motherboard, CPU & RAM",,,2012-11-29 13:05,2012-11-29 16:56,,,

--- a/tests/issue-3.csv
+++ b/tests/issue-3.csv
@@ -1,6 +1,6 @@
-task,category,start,end,effort,ishabit,tags
-Simple Test/Project A/Task on project A,,2017-03-25 14:46,2017-03-25 18:25,,,
-Test task with no headline ancestors,,2017-03-21 17:51,2017-03-22 02:51,,,
-Test missing 3rd level headline/Level 2/Level 4/task,,2012-11-29 13:05,2012-11-29 16:56,,,
-"Test Some commas within the headlines/Are, found/Within, the,/task ancestor's",,2017-03-24 15:16,2017-03-24 19:16,,,
-"Test Some commas within the headlines/Are, found/Within, the,/task ancestor's",,2017-03-25 17:16,2017-03-25 19:16,,,
+task,parents,category,start,end,effort,ishabit,tags
+Task on project A,Simple Test/Project A,,2017-03-25 14:46,2017-03-25 18:25,,,
+Test task with no headline ancestors,,,2017-03-21 17:51,2017-03-22 02:51,,,
+task,Test missing 3rd level headline/Level 2/Level 4,,2012-11-29 13:05,2012-11-29 16:56,,,
+task ancestor's,"Test Some commas within the headlines/Are, found/Within, the,",,2017-03-24 15:16,2017-03-24 19:16,,,
+task ancestor's,"Test Some commas within the headlines/Are, found/Within, the,",,2017-03-25 17:16,2017-03-25 19:16,,,

--- a/tests/issue-3.csv
+++ b/tests/issue-3.csv
@@ -1,4 +1,6 @@
 task,category,start,end,effort,ishabit,tags
-Test1 : task with no headline ancestors,,2017-03-21 17:51,2017-03-22 02:51,,,
-Test2 : missing 3rd level headline/Level 2/Level 4/task,,2012-11-29 13:05,2012-11-29 16:56,,,
-Work/Project A/Task on project A,,2017-03-25 14:46,2017-03-25 18:25,,,
+Simple Test/Project A/Task on project A,,2017-03-25 14:46,2017-03-25 18:25,,,
+Test task with no headline ancestors,,2017-03-21 17:51,2017-03-22 02:51,,,
+Test missing 3rd level headline/Level 2/Level 4/task,,2012-11-29 13:05,2012-11-29 16:56,,,
+"Test Some commas within the headlines/Are, found/Within, the,/task ancestor's",,2017-03-24 15:16,2017-03-24 19:16,,,
+"Test Some commas within the headlines/Are, found/Within, the,/task ancestor's",,2017-03-25 17:16,2017-03-25 19:16,,,

--- a/tests/issue-3.csv
+++ b/tests/issue-3.csv
@@ -1,0 +1,4 @@
+task,category,start,end,effort,ishabit,tags
+Test1 : task with no headline ancestors,,2017-03-21 17:51,2017-03-22 02:51,,,
+Test2 : missing 3rd level headline/Level 2/Level 4/task,,2012-11-29 13:05,2012-11-29 16:56,,,
+Work/Project A/Task on project A,,2017-03-25 14:46,2017-03-25 18:25,,,

--- a/tests/issue-3.org
+++ b/tests/issue-3.org
@@ -1,0 +1,21 @@
+#+TITLE: Issue 3
+
+* Test1 : task with no headline ancestors
+  :LOGBOOK:
+  CLOCK: [2017-03-21 Tue 17:51]--[2017-03-22 Wed 02:51] =>  9:00
+  :END:
+
+* Test2 : missing 3rd level headline
+** Level 2
+**** Level 4
+***** task
+      :LOGBOOK:
+      CLOCK: [2012-11-29 13:05]--[2012-11-29 16:56] =>  3:51
+      :END:
+
+* Work
+** Project A
+*** Task on project A
+    :LOGBOOK:
+    CLOCK: [2017-03-25 Sat 14:46]--[2017-03-25 Sat 18:25] =>  3:39
+    :END:

--- a/tests/issue-3.org
+++ b/tests/issue-3.org
@@ -1,11 +1,18 @@
 #+TITLE: Issue 3
 
-* Test1 : task with no headline ancestors
+* Simple Test
+** Project A
+*** Task on project A
+    :LOGBOOK:
+    CLOCK: [2017-03-25 Sat 14:46]--[2017-03-25 Sat 18:25] =>  3:39
+    :END:
+
+* Test task with no headline ancestors
   :LOGBOOK:
   CLOCK: [2017-03-21 Tue 17:51]--[2017-03-22 Wed 02:51] =>  9:00
   :END:
 
-* Test2 : missing 3rd level headline
+* Test missing 3rd level headline
 ** Level 2
 **** Level 4
 ***** task
@@ -13,9 +20,12 @@
       CLOCK: [2012-11-29 13:05]--[2012-11-29 16:56] =>  3:51
       :END:
 
-* Work
-** Project A
-*** Task on project A
-    :LOGBOOK:
-    CLOCK: [2017-03-25 Sat 14:46]--[2017-03-25 Sat 18:25] =>  3:39
-    :END:
+* Test Some commas within the headlines
+** Are, found
+*** Within, the,
+**** task ancestor's
+     :LOGBOOK:
+     CLOCK: [2017-03-24 Fri 15:16]--[2017-03-24 Fri 19:16] =>  4:00
+     CLOCK: [2017-03-25 Sat 17:16]--[2017-03-25 Sat 19:16] =>  2:00
+     :END:
+

--- a/tests/sample.csv
+++ b/tests/sample.csv
@@ -1,3 +1,3 @@
-task,category,start,end,effort,ishabit,tags
-Example Task,Category,2017-01-01 08:00,2017-01-01 09:00,1:00,,ex1:ex2
-Example Task,Category,2017-01-01 06:00,2017-01-01 07:00,1:00,,ex1:ex2
+task,parents,category,start,end,effort,ishabit,tags
+Example Task,,Category,2017-01-01 08:00,2017-01-01 09:00,1:00,,ex1:ex2
+Example Task,,Category,2017-01-01 06:00,2017-01-01 07:00,1:00,,ex1:ex2


### PR DESCRIPTION
Hi,

Here's a modification that adds the headline ancestors to the task headline. I add two custom variables, one to enable/disable the addition of the headline ancestors to the task headline, and another to control the headline separators.

I also added a minimal test case (issue-3.org) to the test suite.

Feel free to modify it and/or give me comments about it.

Cheers!