### PR TITLE
Add duration and headline to the returned list

### DIFF
--- a/org-clock-csv.el
+++ b/org-clock-csv.el
@@ -190,12 +190,15 @@ properties."
                         (org-clock-csv--pad
                          (org-element-property :hour-end timestamp))
                         (org-clock-csv--pad
-                         (org-element-property :minute-end timestamp)))))
+                         (org-element-property :minute-end timestamp))))
+           (duration (org-element-property :duration element)))
       (list :task task
+            :headline task-headline
             :parents parents
             :category category
             :start start
             :end end
+            :duration duration
             :effort effort
             :ishabit ishabit
             :tags tags))))


### PR DESCRIPTION
I need access to both the `duration` field and custom `:PROPERTIES:`, which are available through `task-headline` calls in my custom `org-clock-csv-default-row-fmt` (which I can overwrite in my own init.el file.