### PR TITLE
Don't display buffer with processed org file

### DIFF
--- a/org-clock-csv.el
+++ b/org-clock-csv.el
@@ -212,7 +212,7 @@ When NO-CHECK is non-nil, skip checking if all files exist."
     ;; files exists first.
     (mapc (lambda (file) (cl-assert (file-exists-p file))) filelist))
   (cl-loop for file in filelist append
-           (with-current-buffer (find-file file)
+           (with-current-buffer (find-file-noselect file)
              (org-element-map (org-element-parse-buffer) 'clock
                #'org-clock-csv--parse-element nil nil))))
 


### PR DESCRIPTION
Thanks for a great package.

I found it a bit annoying that my currently open file is replaced by the processed org agenda file. I don't know if my preference is generally preferrable so could possibly be controlled by a `defcustom` or maybe hooked into the `display-buffer` framework.