### PR TITLE
 Add filename to parsed clock entry list & provide a message when file exists assertion fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
+emacs ?= emacs
+
 test: org-clock-csv-tests.el
-	emacs -batch -f package-initialize -l ert -L . -l $< -f ert-run-tests-batch-and-exit
+	"$(emacs)" -batch -f package-initialize -l ert -L . -l $< -f ert-run-tests-batch-and-exit
 
 .PHONY: test

--- a/org-clock-csv.el
+++ b/org-clock-csv.el
@@ -214,10 +214,12 @@ When NO-CHECK is non-nil, skip checking if all files exist."
     ;; For the sake of better debug messages, check whether all of the
     ;; files exists first.
     (mapc (lambda (file) (cl-assert (file-exists-p file))) filelist))
-  (cl-loop for file in filelist append
-           (with-current-buffer (find-file-noselect file)
-             (org-element-map (org-element-parse-buffer) 'clock
-               #'org-clock-csv--parse-element nil nil))))
+  (cl-loop for file in filelist
+           for entry = (with-current-buffer (find-file-noselect file)
+                         (org-element-map (org-element-parse-buffer) 'clock
+                           #'org-clock-csv--parse-element nil nil))
+           do (plist-put (car entry) :filename file)
+           append entry))
 
 ;;;; Public API:
 

--- a/org-clock-csv.el
+++ b/org-clock-csv.el
@@ -213,7 +213,8 @@ When NO-CHECK is non-nil, skip checking if all files exist."
   (when (not no-check)
     ;; For the sake of better debug messages, check whether all of the
     ;; files exists first.
-    (mapc (lambda (file) (cl-assert (file-exists-p file))) filelist))
+    (mapc (lambda (file)
+            (cl-assert (file-exists-p file) nil "File does not exist: %s" file)) filelist))
   (cl-loop for file in filelist
            for entry = (with-current-buffer (find-file-noselect file)
                          (org-element-map (org-element-parse-buffer) 'clock


### PR DESCRIPTION
Could not get tests to run. Connection issues: 

```
~/code/elisp/org-clock-csv >cask
error in process filter: Could not create connection to orgmode.org:443
~/code/elisp/org-clock-csv >make
"emacs" -batch -f package-initialize -l ert -L . -l org-clock-csv-tests.el -f ert-run-tests-batch-and-exit
Symbol's function definition is void: package-initialize
```