### PR TITLE
Add support for Toggl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Export Clock Entries from org-mode to CSV
 
 `org-clock-csv` is an Emacs package that extracts clock entries from org files
-and convert them into CSV format. It is intended to facilitate clocked time
+and convert them into CSV format.  It is intended to facilitate clocked time
 analysis in external programs.
 
 You can also [read the original blog post][1].
@@ -15,7 +15,7 @@ by cloning the repository and adding the file to your `load-path`.
 
 In interactive mode, calling `org-clock-csv` will open a buffer with the parsed
 entries from the files in `org-agenda-files`, while `org-clock-csv-to-file` will
-write this output to a file. Both functions take a prefix argument to read
+write this output to a file.  Both functions take a prefix argument to read
 entries from the current buffer instead.
 
 Both functions can also be called from lisp code to specify an explicit file
@@ -27,7 +27,7 @@ list argument.
 
 There is an `org-clock-csv-batch-and-exit` command that is designed for use in
 batch mode (essentially, scripting Emacs), which will write CSV content to
-standard output (and then exit). Calling this function is similar to running
+standard output (and then exit).  Calling this function is similar to running
 tests with `ert`:
 
     $ emacs -batch -l path/to/org-clock-csv.el \
@@ -37,19 +37,19 @@ tests with `ert`:
 
 The command accepts a file list as a series of command line arguments (there is
 only one in the example, but more can be given), or uses the content of
-`org-agenda-files` if there are none. You may also want to pipe the output to a
+`org-agenda-files` if there are none.  You may also want to pipe the output to a
 file, as in the example.
 
-Since Emacs is running in batch mode, it will not load your `init.el` file. This
-has two consequences: (1) any `setq` or `customize` code you have written for
-`org` or for this package will not be loaded; and (2) Emacs has not been told
-where your third-party packages are located. So this invokation will likely give
-you the following error:
+Since Emacs is running in batch mode, it will not load your `init.el` file.
+This has two consequences: (1) any `setq` or `customize` code you have written
+for `org` or for this package will not be loaded; and (2) Emacs has not been
+told where your third-party packages are located.  So this invokation will
+likely give you the following error:
 
     Cannot open load file: No such file or directory, s
 
-Since the third-party `s` library is needed to run `org-clock-csv-batch`. You
-can resolve this issue in a few ways. If you don't mind using the default
+Since the third-party `s` library is needed to run `org-clock-csv-batch`.  You
+can resolve this issue in a few ways.  If you don't mind using the default
 settings of `org` and this package, the easiest is simply to let `package.el`
 (which you are probably using already) handle your third-party packages, as
 follows:
@@ -103,10 +103,10 @@ Toggl.  To use it, simply add the following to your init file.
 ## Contributing
 
 Contributions are welcome in the form of pull requests, although the scope of
-this package is intended to be small. If you have an org file that fails to
+this package is intended to be small.  If you have an org file that fails to
 parse as expected, feel free to open an issue.
 
-All code is available under the GPLv3, the same license as Emacs itself. See the
+All code is available under the GPLv3, the same license as Emacs itself.  See the
 `LICENSE` file for details.
 
   [1]: http://unconj.ca/blog/exporting-clock-entries-from-org-mode-to-csv.html

--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ To execute the `org-clock-csv-batch-and-exit` you can then simply run:
 
     cask exec org-clock-csv <file> [files...]
 
+## Additional CSV formats
+
+The package has predefined variables `org-clock-csv-toggl-header` and
+`org-clock-csv-toggl-row-fmt` for CSV
+[files](https://support.toggl.com/en/articles/2216070-editing-and-uploading-a-csv-file)
+to be imported by Toggl.  To use it, simply add the following to your init file.
+
+```elisp
+(setq-default org-clock-csv-header org-clock-csv-toggl-header)
+(setq-default org-clock-csv-row-fmt 'org-clock-csv-toggl-row-fmt)
+```
+
 ## Contributing
 
 Contributions are welcome in the form of pull requests, although the scope of

--- a/README.md
+++ b/README.md
@@ -4,14 +4,12 @@
 and convert them into CSV format. It is intended to facilitate clocked time
 analysis in external programs.
 
-You can also
-[read the original blog post](http://unconj.ca/blog/exporting-clock-entries-from-org-mode-to-csv.html).
+You can also [read the original blog post][1].
 
-## Installation [![MELPA](http://melpa.org/packages/org-clock-csv-badge.svg)](http://melpa.org/#/org-clock-csv)
+## Installation [![MELPA](http://melpa.org/packages/org-clock-csv-badge.svg)][2]
 
-`org-clock-csv` is available from [MELPA](http://melpa.org/#/org-clock-csv). You
-can also install it manually by cloning the repository and adding the file to
-your `load-path`.
+`org-clock-csv` is available from [MELPA][2].  You can also install it manually
+by cloning the repository and adding the file to your `load-path`.
 
 ## Usage in Interactive Mode
 
@@ -85,18 +83,17 @@ follows:
 
 ### Cask
 
-If you are using [Cask](https://github.com/cask/cask) you can clone
-the repository and run `cask install` to install all the dependencies.
-To execute the `org-clock-csv-batch-and-exit` you can then simply run:
+If you are using [Cask][3] you can clone the repository and run `cask install`
+to install all the dependencies.  To execute the `org-clock-csv-batch-and-exit`
+you can then simply run:
 
     cask exec org-clock-csv <file> [files...]
 
 ## Additional CSV formats
 
 The package has predefined variables `org-clock-csv-toggl-header` and
-`org-clock-csv-toggl-row-fmt` for CSV
-[files](https://support.toggl.com/en/articles/2216070-editing-and-uploading-a-csv-file)
-to be imported by Toggl.  To use it, simply add the following to your init file.
+`org-clock-csv-toggl-row-fmt` for exporting CSV [files][4] to be imported by
+Toggl.  To use it, simply add the following to your init file.
 
 ```elisp
 (setq-default org-clock-csv-header org-clock-csv-toggl-header)
@@ -111,3 +108,8 @@ parse as expected, feel free to open an issue.
 
 All code is available under the GPLv3, the same license as Emacs itself. See the
 `LICENSE` file for details.
+
+  [1]: http://unconj.ca/blog/exporting-clock-entries-from-org-mode-to-csv.html
+  [2]: http://melpa.org/#/org-clock-csv
+  [3]: https://github.com/cask/cask
+  [4]: https://support.toggl.com/en/articles/2216070-editing-and-uploading-a-csv-file

--- a/org-clock-csv.el
+++ b/org-clock-csv.el
@@ -70,7 +70,7 @@ Be sure to keep this in sync with changes to
 `org-clock-csv-row-fmt'."
   :group 'org-clock-csv)
 
-(defcustom org-clock-csv-toggl-header "Description,Project,Start Date,Start Time,Duration,Email"
+(defcustom org-clock-csv-toggl-header "Description,Start Date,Start Time,Duration,Email"
   "Header for the CSV output that is in sync with `org-clock-csv-toggl-row-fmt'"
   :group 'org-clock-csv)
 
@@ -104,15 +104,12 @@ See `org-clock-csv-default-row-fmt' for an example."
 (defun org-clock-csv-toggl-row-fmt (plist)
   "Toggl row formatting function."
   (let* ((task (org-clock-csv--escape (plist-get plist :task)))
-         (project (org-clock-csv--escape
-                   (or (car (plist-get plist :parents))
-                       task)))
          (start (date-to-time (plist-get plist :start)))
          (start-date (format-time-string "%F" start))
          (start-time (format-time-string "%H:%M:%S" start))
          (end (date-to-time (plist-get plist :end)))
          (duration (format-seconds "%h:%m:%s" (float-time (time-subtract end start)))))
-    (s-join "," (list task project start-date start-time duration user-mail-address))))
+    (s-join "," (list task start-date start-time duration user-mail-address))))
 
 ;;;; Utility functions:
 

--- a/org-clock-csv.el
+++ b/org-clock-csv.el
@@ -70,6 +70,10 @@ Be sure to keep this in sync with changes to
 `org-clock-csv-row-fmt'."
   :group 'org-clock-csv)
 
+(defcustom org-clock-csv-toggl-header "Description,Project,Start Date,Start Time,Duration,Email"
+  "Header for the CSV output that is in sync with `org-clock-csv-toggl-row-fmt'"
+  :group 'org-clock-csv)
+
 (defcustom org-clock-csv-headline-separator "/"
   "Character that separates each headline level within the \"task\" column."
   :group 'org-clock-csv)
@@ -96,6 +100,19 @@ See `org-clock-csv-default-row-fmt' for an example."
                    (plist-get plist ':ishabit)
                    (plist-get plist ':tags))
              ","))
+
+(defun org-clock-csv-toggl-row-fmt (plist)
+  "Toggl row formatting function."
+  (let* ((task (org-clock-csv--escape (plist-get plist :task)))
+         (project (org-clock-csv--escape
+                   (or (car (plist-get plist :parents))
+                       task)))
+         (start (date-to-time (plist-get plist :start)))
+         (start-date (format-time-string "%F" start))
+         (start-time (format-time-string "%H:%M:%S" start))
+         (end (date-to-time (plist-get plist :end)))
+         (duration (format-seconds "%h:%m:%s" (float-time (time-subtract end start)))))
+    (s-join "," (list task project start-date start-time duration user-mail-address))))
 
 ;;;; Utility functions:
 


### PR DESCRIPTION
Also update README.md with reference-style links and separate sentences with two spaces.  After all, `org-mode` is for Emacs, and in Emacs, reference-style links looks much better for markdown and sentences are conventionally separated by two spaces (English spacing instead of [French spacing][1] using typographical jargons).

  [1]: https://en.wikipedia.org/wiki/History_of_sentence_spacing#French_and_English_spacing