### PR TITLE
Store title or filename in a new column

### DIFF
--- a/org-clock-csv-tests.el
+++ b/org-clock-csv-tests.el
@@ -14,7 +14,7 @@
     (should (equal in out))))
 
 (defvar org-clock-csv-header-all-props
-  "task,headline,parents,category,start,end,duration,effort,ishabit,tags")
+  "task,headline,parents,category,start,end,duration,effort,ishabit,tags,title")
 
 (defun org-clock-csv-all-props-row-fmt (plist)
   "Formatting function including all properties."
@@ -31,7 +31,8 @@
                    (plist-get plist ':duration)
                    (plist-get plist ':effort)
                    (plist-get plist ':ishabit)
-                   (plist-get plist ':tags))
+                   (plist-get plist ':tags)
+                   (plist-get plist ':title))
              ","))
 
 ;;; Tests:
@@ -53,6 +54,12 @@
 (ert-deftest test-issue-3 ()
   "Test tasks with headline ancestors, as in issue #3."
   (org-clock-csv-should-match "tests/issue-3.org" "tests/issue-3.csv"))
+
+(ert-deftest test-issue-26 ()
+  "Test file without title."
+  (let ((org-clock-csv-header org-clock-csv-header-all-props)
+        (org-clock-csv-row-fmt #'org-clock-csv-all-props-row-fmt))
+    (org-clock-csv-should-match "tests/issue-26.org" "tests/issue-26.csv")))
 
 ;; Local Variables:
 ;; coding: utf-8

--- a/tests/all-props.csv
+++ b/tests/all-props.csv
@@ -1,3 +1,3 @@
-task,headline,parents,category,start,end,duration,effort,ishabit,tags
-Example Task,Example Task,,Category,2017-01-01 08:00,2017-01-01 09:00,1:00,1:00,,ex1:ex2
-Example Task,Example Task,,Category,2017-01-01 06:00,2017-01-01 07:00,1:00,1:00,,ex1:ex2
+task,headline,parents,category,start,end,duration,effort,ishabit,tags,title
+Example Task,Example Task,,Category,2017-01-01 08:00,2017-01-01 09:00,1:00,1:00,,ex1:ex2,Sample
+Example Task,Example Task,,Category,2017-01-01 06:00,2017-01-01 07:00,1:00,1:00,,ex1:ex2,Sample

--- a/tests/issue-26.csv
+++ b/tests/issue-26.csv
@@ -1,0 +1,3 @@
+task,headline,parents,category,start,end,duration,effort,ishabit,tags,title
+Example Task,Example Task,,Category,2017-01-01 08:00,2017-01-01 09:00,1:00,1:00,,ex1:ex2,tests/issue-26.org
+Example Task,Example Task,,Category,2017-01-01 06:00,2017-01-01 07:00,1:00,1:00,,ex1:ex2,tests/issue-26.org

--- a/tests/issue-26.org
+++ b/tests/issue-26.org
@@ -1,0 +1,9 @@
+* TODO Example Task                                                                        :ex1:ex2:
+  :PROPERTIES:
+  :CATEGORY: Category
+  :Effort:   1:00
+  :END:
+  :LOGBOOK:
+  CLOCK: [2017-01-01 Sun 08:00]--[2017-01-01 Sun 09:00] =>  1:00
+  CLOCK: [2017-01-01 Sun 06:00]--[2017-01-01 Sun 07:00] =>  1:00
+  :END:


### PR DESCRIPTION
This is an attempt to solve #26 but as I am not sure to fully understand the issue mentioned in #5 it may fall into this pitfall.

Because the title affects the whole file and does not depend on the headline being analyzed, the `org-clock-csv--parse-element` function is called with an extra argument (the cached value mentioned in the comments) obtained by a call to `org-clock-cas--get-title`.

This new function indeed calls `org-element-map` to look for `keyword`. By using the `FIRST-MATCH` argument the search is limited to the first appearance of the token because the lambda looking for the TITLE property always returns a non-nil value. In addition, `keyword` is bound to be at the beginning of the AST so the search should be quick.

I added a column to the `all-props` test and created a specific `issue-26` test to check that the filename is correctly returned when there is no TITLE.

I also considered calling `file-name-nondirectory` on the file paths supplied to `org-clock-csv--get-entries` but am not sure this would be useful to users.

Thank you in advance for taking the time to review this and pointing what I am certainly missing.