### PR TITLE
File level category as default

### DIFF
--- a/org-clock-csv-tests.el
+++ b/org-clock-csv-tests.el
@@ -57,7 +57,7 @@
 
 (ert-deftest test-issue-5 ()
   "Test file level category."
-  (org-clock-csv-should-match "tests/issue-5.org" "tests/sample.csv"))
+  (org-clock-csv-should-match "tests/issue-5.org" "tests/issue-5.csv"))
 
 (ert-deftest test-issue-26 ()
   "Test file without title."

--- a/org-clock-csv-tests.el
+++ b/org-clock-csv-tests.el
@@ -55,6 +55,10 @@
   "Test tasks with headline ancestors, as in issue #3."
   (org-clock-csv-should-match "tests/issue-3.org" "tests/issue-3.csv"))
 
+(ert-deftest test-issue-5 ()
+  "Test file level category."
+  (org-clock-csv-should-match "tests/issue-5.org" "tests/sample.csv"))
+
 (ert-deftest test-issue-26 ()
   "Test file without title."
   (let ((org-clock-csv-header org-clock-csv-header-all-props)

--- a/org-clock-csv.el
+++ b/org-clock-csv.el
@@ -114,11 +114,11 @@ sufficient to escape commas and double quote characters."
 
 ;;;; Internal API:
 
-(defun org-clock-csv--find-category (element)
+(defun org-clock-csv--find-category (element default)
   "Find the category of a headline ELEMENT, optionally recursing
 upwards until one is found.
 
-Returns an empty string if no category is found."
+Returns the DEFAULT file level category if none is found."
   (let ((category (org-element-property :CATEGORY element))
         (current element)
         (curlvl  (org-element-property :level element)))
@@ -132,16 +132,9 @@ Returns an empty string if no category is found."
             curlvl (- curlvl 1))
       (setq category (org-element-property :CATEGORY current))
       ;; If we get to the root of the org file with no category, just
-      ;; set it to the empty string.
-      ;;
-      ;; TODO: File-level categories are stored not as properties, but
-      ;; as keyword elements in the `org-data' structure. In order to
-      ;; extract them, it will probaby require a call to
-      ;; `org-element-map'. Since this could be an expensive operation
-      ;; on an org file with no headline-level categories, but a
-      ;; single file-level category, it would need to be cached.
+      ;; set it to the default file level category.
       (unless (equal 'headline (org-element-type current))
-        (setq category "")))
+        (setq category default)))
     category))
 
 (defun org-clock-csv--find-headlines (element)
@@ -150,7 +143,7 @@ Returns an empty string if no category is found."
     (if ph
       (cons ph (org-clock-csv--find-headlines ph)))))
 
-(defun org-clock-csv--parse-element (element title)
+(defun org-clock-csv--parse-element (element title default-category)
   "Ingest clock ELEMENT and produces a plist of its relevant
 properties."
   (when (and (equal (org-element-type element) 'clock)
@@ -173,7 +166,7 @@ properties."
            (ishabit (when (equal "habit" (org-element-property
                                           :STYLE task-headline))
                       "t"))
-           (category (org-clock-csv--find-category task-headline))
+           (category (org-clock-csv--find-category task-headline default-category))
            (start (format "%d-%s-%s %s:%s"
                           (org-element-property :year-start timestamp)
                           (org-clock-csv--pad
@@ -207,14 +200,15 @@ properties."
             :ishabit ishabit
             :tags tags))))
 
-(defun org-clock-csv--get-title (filename AST)
-  "Return the title or the filename of the document."
-  (let ((title (org-element-map AST 'keyword
-		     (lambda (elem) (if (string-equal (org-element-property :key elem) 'TITLE)
-					(org-element-property :value elem)
-				      filename))
-		     nil t)))
-    (if (equal nil title) filename title)))
+(defun org-clock-csv--get-org-data (property ast default)
+  "Return the PROPERTY of the `org-data' structure in the AST
+or the DEFAULT value if it does not exist."
+  (let ((value (org-element-map ast 'keyword
+		 (lambda (elem) (if (string-equal (org-element-property :key elem) property)
+				    (org-element-property :value elem)
+				  default))
+		 nil t)))
+    (if (equal nil value) default value)))
 
 (defun org-clock-csv--get-entries (filelist &optional no-check)
   "Retrieves clock entries from files in FILELIST.
@@ -226,10 +220,11 @@ When NO-CHECK is non-nil, skip checking if all files exist."
     (mapc (lambda (file) (cl-assert (file-exists-p file))) filelist))
   (cl-loop for file in filelist append
            (with-current-buffer (find-file-noselect file)
-	     (let* ((AST (org-element-parse-buffer))
-		    (title (org-clock-csv--get-title file AST)))
-	       (org-element-map AST 'clock
-		 (lambda (c) (org-clock-csv--parse-element c title))
+	     (let* ((ast (org-element-parse-buffer))
+		    (title (org-clock-csv--get-org-data 'TITLE ast file))
+		    (category (org-clock-csv--get-org-data 'CATEGORY ast "")))
+	       (org-element-map ast 'clock
+		 (lambda (c) (org-clock-csv--parse-element c title category))
 		     nil nil)))))
 
 ;;;; Public API:

--- a/org-clock-csv.el
+++ b/org-clock-csv.el
@@ -205,10 +205,8 @@ properties."
 or the DEFAULT value if it does not exist."
   (let ((value (org-element-map ast 'keyword
 		 (lambda (elem) (if (string-equal (org-element-property :key elem) property)
-				    (org-element-property :value elem)
-				  default))
-		 nil t)))
-    (if (equal nil value) default value)))
+				    (org-element-property :value elem))))))
+    (if (equal nil value) default (car value))))
 
 (defun org-clock-csv--get-entries (filelist &optional no-check)
   "Retrieves clock entries from files in FILELIST.

--- a/tests/issue-5.csv
+++ b/tests/issue-5.csv
@@ -1,0 +1,3 @@
+task,parents,category,start,end,effort,ishabit,tags
+Task with no category,,Main category,2017-01-01 08:00,2017-01-01 09:00,1:00,,ex1:ex2
+Task with category,,Other category,2017-01-01 06:00,2017-01-01 07:00,1:00,,

--- a/tests/issue-5.org
+++ b/tests/issue-5.org
@@ -1,0 +1,10 @@
+#+CATEGORY: Category
+
+* TODO Example Task                                                                        :ex1:ex2:
+  :PROPERTIES:
+  :Effort:   1:00
+  :END:
+  :LOGBOOK:
+  CLOCK: [2017-01-01 Sun 08:00]--[2017-01-01 Sun 09:00] =>  1:00
+  CLOCK: [2017-01-01 Sun 06:00]--[2017-01-01 Sun 07:00] =>  1:00
+  :END:

--- a/tests/issue-5.org
+++ b/tests/issue-5.org
@@ -1,10 +1,18 @@
-#+CATEGORY: Category
+#+CATEGORY: Main category
 
-* TODO Example Task                                                                        :ex1:ex2:
+* Task with no category                                             :ex1:ex2:
   :PROPERTIES:
   :Effort:   1:00
   :END:
   :LOGBOOK:
   CLOCK: [2017-01-01 Sun 08:00]--[2017-01-01 Sun 09:00] =>  1:00
+  :END:
+
+* Task with category
+  :PROPERTIES:
+  :CATEGORY: Other category
+  :Effort:   1:00
+  :END:
+  :LOGBOOK:
   CLOCK: [2017-01-01 Sun 06:00]--[2017-01-01 Sun 07:00] =>  1:00
   :END:

--- a/tests/issue-5.org
+++ b/tests/issue-5.org
@@ -1,3 +1,4 @@
+#+STARTUP: content
 #+CATEGORY: Main category
 
 * Task with no category                                             :ex1:ex2:

--- a/tests/sample.org
+++ b/tests/sample.org
@@ -1,3 +1,4 @@
+#+STARTUP: content
 #+TITLE: Sample
 
 * TODO Example Task                                                                        :ex1:ex2:


### PR DESCRIPTION
Following up on the resolution of #26, here is a generalization of the `org-clock-csv--get-title` function to fetch `org-data` keywords (function `org-clock-csv--get-org-data`). It is then used to solve #5.

One `issue-5` test is added to check that a headline without a category is correctly associated with the file level category.

Thanks in advance for your review. 